### PR TITLE
[FIX] Added barbatrick to allow app to wait for eyca async activation

### DIFF
--- a/apps/card-func/EycaActivation_2_ProcessPendingQueue/handler.ts
+++ b/apps/card-func/EycaActivation_2_ProcessPendingQueue/handler.ts
@@ -1,5 +1,5 @@
 import { Context } from "@azure/functions";
-import { FiscalCode, NonEmptyString } from "@pagopa/ts-commons/lib/strings";
+import { FiscalCode } from "@pagopa/ts-commons/lib/strings";
 import { pipe } from "fp-ts/lib/function";
 import * as O from "fp-ts/lib/Option";
 import * as TE from "fp-ts/lib/TaskEither";
@@ -7,7 +7,6 @@ import { StatusEnum as ActivatedStatusEnum } from "../generated/definitions/Card
 import { StatusEnum as PendingStatusEnum } from "../generated/definitions/CardPending";
 import { UserEycaCard, UserEycaCardModel } from "../models/user_eyca_card";
 import { CardPendingMessage } from "../types/queue-message";
-import { fromBase64, toBase64 } from "../utils/base64";
 import { throwError, trackError } from "../utils/errors";
 import { PreIssueEycaCard } from "../utils/eyca";
 import { QueueStorage } from "../utils/queue";

--- a/apps/card-func/GetEycaStatus/handler.ts
+++ b/apps/card-func/GetEycaStatus/handler.ts
@@ -7,6 +7,7 @@ import {
   withRequestMiddlewares,
   wrapRequestHandler
 } from "@pagopa/io-functions-commons/dist/src/utils/request_middleware";
+import { NonNegativeInteger } from "@pagopa/ts-commons/lib/numbers";
 import {
   IResponseErrorConflict,
   IResponseErrorForbiddenNotAuthorized,
@@ -22,13 +23,15 @@ import {
 import { FiscalCode } from "@pagopa/ts-commons/lib/strings";
 import { flow, pipe } from "fp-ts/lib/function";
 import * as TE from "fp-ts/lib/TaskEither";
-
-import { NonNegativeInteger } from "@pagopa/ts-commons/lib/numbers";
-import { CardPending } from "../generated/definitions/CardPending";
+import {
+  CardPending,
+  StatusEnum as PendingStatusEnum
+} from "../generated/definitions/CardPending";
 import { EycaCard } from "../generated/definitions/EycaCard";
 import { UserCgnModel } from "../models/user_cgn";
 import { UserEycaCardModel } from "../models/user_eyca_card";
 import { isEycaEligible } from "../utils/cgn_checks";
+import { CardActivated } from "../generated/definitions/CardActivated";
 
 type ErrorTypes =
   | IResponseErrorNotFound
@@ -42,12 +45,26 @@ type IGetEycaStatusHandler = (
   fiscalCode: FiscalCode
 ) => Promise<ResponseTypes>;
 
-// eslint-disable-next-line prefer-arrow/prefer-arrow-functions
-export function GetEycaStatusHandler(
+const pendingEycaTE = TE.of({
+  status: PendingStatusEnum.PENDING
+});
+
+const conflictEycaTE = TE.left(
+  ResponseErrorConflict(
+    "EYCA Card is missing while citizen is eligible to obtain it"
+  )
+);
+
+const timeToWaitInMilliseconds = 60000; // 60 seconds
+
+const tooEarlyToDetermineEycaFailure = (activationDate: Date) =>
+  new Date().getTime() - activationDate.getTime() <= timeToWaitInMilliseconds;
+
+export const GetEycaStatusHandler = (
   userEycaCardModel: UserEycaCardModel,
   userCgnModel: UserCgnModel,
   eycaUpperBoundAge: NonNegativeInteger
-): IGetEycaStatusHandler {
+): IGetEycaStatusHandler => {
   // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
   return async (_, fiscalCode) =>
     pipe(
@@ -94,15 +111,22 @@ export function GetEycaStatusHandler(
                   TE.fromOption(() => notFoundError)
                 )
               ),
-              TE.chainW(
-                TE.fromPredicate(
-                  userCgn => CardPending.is(userCgn.card),
-                  () =>
-                    ResponseErrorConflict(
-                      "EYCA Card is missing while citizen is eligible to obtain it"
-                    )
-                )
-              ),
+              TE.chainW(userCgn => {
+                const cgnCard = userCgn.card;
+                const isCgnPending = CardPending.is(cgnCard);
+                const isCgnActivated = CardActivated.is(cgnCard);
+
+                // we check if a cgn card is pending or if a reasonable amount of time
+                // is passed from an activated cgn:
+                // - if cgn is pending or activated less tha T ago we return a "fake" pending eyca
+                // - if it's passed greater that T time then we return a conflict
+                // T = 60 seconds
+                return isCgnPending ||
+                  (isCgnActivated &&
+                    tooEarlyToDetermineEycaFailure(cgnCard.activation_date))
+                  ? pendingEycaTE
+                  : conflictEycaTE;
+              }),
               TE.chainW(() => TE.left(notFoundError))
             )
           )
@@ -111,14 +135,13 @@ export function GetEycaStatusHandler(
       TE.map(userEycaCard => ResponseSuccessJson(userEycaCard.card)),
       TE.toUnion
     )();
-}
+};
 
-// eslint-disable-next-line prefer-arrow/prefer-arrow-functions
-export function GetEycaStatus(
+export const GetEycaStatus = (
   userEycaCardModel: UserEycaCardModel,
   userCgnModel: UserCgnModel,
   eycaUpperBoundAge: NonNegativeInteger
-): express.RequestHandler {
+): express.RequestHandler => {
   const handler = GetEycaStatusHandler(
     userEycaCardModel,
     userCgnModel,
@@ -131,4 +154,4 @@ export function GetEycaStatus(
   );
 
   return wrapRequestHandler(middlewaresWrap(handler));
-}
+};


### PR DESCRIPTION
#### List of Changes
- Added checks on cgn status and cgn activation time before returning Eyca Conflict error

#### Motivation and Context
With the new queue triggered functions we have a perfectly async activation process, so we have to return a card pending if eyca while eyca is being activated in a reasonable amount of time. 
We decided that 60 seconds should be enough to have an eyca card after cgn has been activated.
If an eyca is not activated after 60 seconds we return the conflict.

#### How Has This Been Tested?
Unit tests.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

