### PR TITLE
[#PE-626] Added numberOfNewDiscounts property to merchants' search APIs

### DIFF
--- a/.changeset/orange-dingos-design.md
+++ b/.changeset/orange-dingos-design.md
@@ -1,0 +1,5 @@
+---
+"search-func": minor
+---
+
+Added numberOfNewDiscounts column to merchants API

--- a/apps/search-func/GetOfflineMerchants/__tests__/handler.test.ts
+++ b/apps/search-func/GetOfflineMerchants/__tests__/handler.test.ts
@@ -130,6 +130,47 @@ describe("GetOfflineMerchantsHandler", () => {
     }
   });
 
+  it("should return the result with numberOfNewDiscounts if new discounts are present", async () => {
+    queryMock.mockReturnValueOnce(
+      new Promise(resolve => {
+        resolve([
+          {
+            ...anOfflineMerchant,
+            number_of_new_discounts: 1,
+            product_categories: [
+              ProductCategoryEnumModelType.cultureAndEntertainment,
+              ProductCategoryEnumModelType.home,
+              ProductCategoryEnumModelType.learning,
+              ProductCategoryEnumModelType.health
+            ]
+          }
+        ]);
+      })
+    );
+    const response = await GetOfflineMerchantsHandler(cgnOperatorDbMock as any)(
+      mockContext,
+      aSearchRequestBody as OfflineMerchantSearchRequest
+    );
+    expect(queryMock).toBeCalledTimes(1);
+    expect(response.kind).toBe("IResponseSuccessJson");
+    if (response.kind === "IResponseSuccessJson") {
+      expect(response.value).toEqual({
+        items: [
+          {
+            ...anOfflineMerchantResponse,
+            numberOfNewDiscounts: 1,
+            productCategories: [
+              ProductCategoryEnum.cultureAndEntertainment,
+              ProductCategoryEnum.home,
+              ProductCategoryEnum.learning,
+              ProductCategoryEnum.health
+            ]
+          }
+        ]
+      });
+    }
+  });
+
   it("should add to the db query the merchant name filter, lowering its case", async () => {
     queryMock.mockImplementationOnce((query, params) => {
       expect(query).toMatch(/AND searchable_name LIKE/);

--- a/apps/search-func/GetOfflineMerchants/handler.ts
+++ b/apps/search-func/GetOfflineMerchants/handler.ts
@@ -104,6 +104,7 @@ export const GetOfflineMerchantsHandler = (
                 ),
                 O.getOrElse(() => true) // no category filter => maintain the queried flag
               ),
+            numberOfNewDiscounts: offlineMerchant.number_of_new_discounts,
             productCategories: offlineMerchant.product_categories.map(pc =>
               ProductCategoryFromModel(pc)
             )

--- a/apps/search-func/GetOnlineMerchants/__tests__/handler.test.ts
+++ b/apps/search-func/GetOnlineMerchants/__tests__/handler.test.ts
@@ -1,5 +1,8 @@
 /* tslint:disable: no-any */
-import { DiscountCodeType, DiscountCodeTypeEnum } from "../../generated/definitions/DiscountCodeType";
+import {
+  DiscountCodeType,
+  DiscountCodeTypeEnum
+} from "../../generated/definitions/DiscountCodeType";
 import { OnlineMerchantSearchRequest } from "../../generated/definitions/OnlineMerchantSearchRequest";
 import { ProductCategoryEnum } from "../../generated/definitions/ProductCategory";
 import { DiscountCodeTypeEnumModel } from "../../models/DiscountCodeTypes";
@@ -47,7 +50,10 @@ const anOnlineMerchantResponse = {
   name: anOnlineMerchant.name,
   websiteUrl: anOnlineMerchant.website_url,
   discountCodeType: DiscountCodeTypeEnum.static,
-  productCategories: [ProductCategoryEnum.cultureAndEntertainment, ProductCategoryEnum.sports],
+  productCategories: [
+    ProductCategoryEnum.cultureAndEntertainment,
+    ProductCategoryEnum.sports
+  ],
   newDiscounts: true
 };
 
@@ -100,6 +106,47 @@ describe("GetOnlineMerchantsHandler", () => {
     }
   });
 
+  it("should return the result with numberOfNewDiscounts if new discounts are present", async () => {
+    queryMock.mockReturnValueOnce(
+      new Promise(resolve => {
+        resolve([
+          {
+            ...anOnlineMerchant,
+            number_of_new_discounts: 1,
+            product_categories: [
+              ProductCategoryEnumModelType.cultureAndEntertainment,
+              ProductCategoryEnumModelType.home,
+              ProductCategoryEnumModelType.learning,
+              ProductCategoryEnumModelType.health
+            ]
+          }
+        ]);
+      })
+    );
+    const response = await GetOnlineMerchantsHandler(cgnOperatorDbMock as any)(
+      {} as any,
+      searchRequestBody as OnlineMerchantSearchRequest
+    );
+    expect(queryMock).toBeCalledTimes(1);
+    expect(response.kind).toBe("IResponseSuccessJson");
+    if (response.kind === "IResponseSuccessJson") {
+      expect(response.value).toEqual({
+        items: [
+          {
+            ...anOnlineMerchantResponse,
+            numberOfNewDiscounts: 1,
+            productCategories: [
+              ProductCategoryEnum.cultureAndEntertainment,
+              ProductCategoryEnum.home,
+              ProductCategoryEnum.learning,
+              ProductCategoryEnum.health
+            ]
+          }
+        ]
+      });
+    }
+  });
+
   it("should add to the db query the merchant name filter, lowering its case", async () => {
     queryMock.mockImplementationOnce((query, params) => {
       expect(query).toMatch(/AND searchable_name LIKE/);
@@ -110,7 +157,7 @@ describe("GetOnlineMerchantsHandler", () => {
 
     const response = await GetOnlineMerchantsHandler(cgnOperatorDbMock as any)(
       {} as any,
-      {merchantName: "A Company"} as OnlineMerchantSearchRequest
+      { merchantName: "A Company" } as OnlineMerchantSearchRequest
     );
     expect(queryMock).toBeCalledTimes(1);
     expect(response.kind).toBe("IResponseSuccessJson");
@@ -125,7 +172,12 @@ describe("GetOnlineMerchantsHandler", () => {
 
     const response = await GetOnlineMerchantsHandler(cgnOperatorDbMock as any)(
       {} as any,
-       {productCategories: [ProductCategoryEnum.health, ProductCategoryEnum.cultureAndEntertainment]} as OnlineMerchantSearchRequest 
+      {
+        productCategories: [
+          ProductCategoryEnum.health,
+          ProductCategoryEnum.cultureAndEntertainment
+        ]
+      } as OnlineMerchantSearchRequest
     );
     expect(queryMock).toBeCalledTimes(1);
     expect(response.kind).toBe("IResponseSuccessJson");
@@ -142,13 +194,16 @@ describe("GetOnlineMerchantsHandler", () => {
 
     const response = await GetOnlineMerchantsHandler(cgnOperatorDbMock as any)(
       {} as any,
-      {productCategories: [ProductCategoryEnum.travelling,
-        ProductCategoryEnum.sports,
-        ProductCategoryEnum.home,
-        ProductCategoryEnum.learning,
-        ProductCategoryEnum.sports,
-        ProductCategoryEnum.health]} as OnlineMerchantSearchRequest 
-
+      {
+        productCategories: [
+          ProductCategoryEnum.travelling,
+          ProductCategoryEnum.sports,
+          ProductCategoryEnum.home,
+          ProductCategoryEnum.learning,
+          ProductCategoryEnum.sports,
+          ProductCategoryEnum.health
+        ]
+      } as OnlineMerchantSearchRequest
     );
     expect(queryMock).toBeCalledTimes(1);
     expect(response.kind).toBe("IResponseSuccessJson");
@@ -163,7 +218,7 @@ describe("GetOnlineMerchantsHandler", () => {
 
     const response = await GetOnlineMerchantsHandler(cgnOperatorDbMock as any)(
       {} as any,
-      {page: 2, pageSize: 10} as OnlineMerchantSearchRequest 
+      { page: 2, pageSize: 10 } as OnlineMerchantSearchRequest
     );
     expect(queryMock).toBeCalledTimes(1);
     expect(response.kind).toBe("IResponseSuccessJson");
@@ -179,7 +234,7 @@ describe("GetOnlineMerchantsHandler", () => {
 
     const response = await GetOnlineMerchantsHandler(cgnOperatorDbMock as any)(
       {} as any,
-      {page: 0, pageSize: 20} as OnlineMerchantSearchRequest 
+      { page: 0, pageSize: 20 } as OnlineMerchantSearchRequest
     );
     expect(queryMock).toBeCalledTimes(1);
     expect(response.kind).toBe("IResponseErrorInternal");

--- a/apps/search-func/GetOnlineMerchants/handler.ts
+++ b/apps/search-func/GetOnlineMerchants/handler.ts
@@ -95,6 +95,7 @@ export const GetOnlineMerchantsHandler = (
               ),
               O.getOrElse(() => true) // no category filter => maintain the queried flag
             ),
+          numberOfNewDiscounts: onlineMerchant.number_of_new_discounts,
           productCategories: pipe(
             [...onlineMerchant.product_categories],
             AR.map(ProductCategoryFromModel)

--- a/apps/search-func/models/OfflineMerchantModel.ts
+++ b/apps/search-func/models/OfflineMerchantModel.ts
@@ -16,4 +16,5 @@ export default class OfflineMerchantModel extends Model {
   public readonly categories_with_new_discounts?: ReadonlyArray<
     ProductCategoryEnumModelType
   >;
+  public readonly number_of_new_discounts?: number;
 }

--- a/apps/search-func/models/OnlineMerchantModel.ts
+++ b/apps/search-func/models/OnlineMerchantModel.ts
@@ -15,4 +15,5 @@ export default class OnlineMerchantModel extends Model {
   public readonly categories_with_new_discounts?: ReadonlyArray<
     ProductCategoryEnumModelType
   >;
+  public readonly number_of_new_discounts?: number;
 }

--- a/apps/search-func/openapi/index.yaml
+++ b/apps/search-func/openapi/index.yaml
@@ -383,6 +383,8 @@ definitions:
         $ref: "#/definitions/DiscountCodeType"
       newDiscounts:
         type: boolean
+      numberOfNewDiscounts:
+        type: number
 
   OfflineMerchants:
     type: object
@@ -421,6 +423,8 @@ definitions:
         minimum: 0
       newDiscounts:
         type: boolean
+      numberOfNewDiscounts:
+        type: number
 
   Address:
     type: object

--- a/apps/search-func/utils/postgres_queries.ts
+++ b/apps/search-func/utils/postgres_queries.ts
@@ -118,7 +118,8 @@ SELECT
   website_url,
   discount_code_type,
   new_discounts,
-  categories_with_new_discounts
+  categories_with_new_discounts,
+  number_of_new_discounts
 FROM online_merchant
 WHERE 1 = 1
   ${nameFilterQueryPart(nameFilter)}
@@ -137,6 +138,7 @@ SELECT
   full_address AS address,
   new_discounts,
   categories_with_new_discounts,
+  number_of_new_discounts,
   latitude,
   longitude${pipe(
     searchRequest.userCoordinates,


### PR DESCRIPTION
#### List of Changes
Added `numberOfNewDiscounts` to `OnlineMerchant` and `OfflineMerchant`.
This value is taken from the materialized views, it is greater than 0 and will be returned only for merchants with new discounts.

#### Motivation and Context
We want to show a badge with the number of new discount aside the merchants' name.

#### How Has This Been Tested?
- unit tests

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
