### PR TITLE
[#PE-950] Saved usage_datetime for discount bucket code during update

### DIFF
--- a/apps/search-func/utils/postgres_queries.ts
+++ b/apps/search-func/utils/postgres_queries.ts
@@ -267,7 +267,7 @@ SKIP LOCKED`;
 
 export const UpdateDiscountBucketCodeSetUsed = `
 UPDATE discount_bucket_code
-SET used = true 
+SET used = true, usage_datetime = CURRENT_TIMESTAMP 
 WHERE bucket_code_k in (:bucket_code_k_list)`;
 
 export const SelectPublishedProductCategories = `


### PR DESCRIPTION
#### List of Changes
- update the column `usage_datetime` during `discount_bucket_code` update

#### Motivation and Context
We want to track the datetime we burn the codes in batches.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
