### PR TITLE
Migrate card-func and support-func to RBAC-based storage access

### DIFF
--- a/apps/card-func/env.example
+++ b/apps/card-func/env.example
@@ -4,7 +4,10 @@ COSMOSDB_PORT=3000
 API_GATEWAY_PORT=80
 
 FUNCTIONS_WORKER_RUNTIME=node
-CGN_STORAGE_CONNECTION_STRING=DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://fnstorage:10000/devstoreaccount1;QueueEndpoint=http://fnstorage:10001/devstoreaccount1;TableEndpoint=http://fnstorage:10002/devstoreaccount1;
+# For local dev with Azurite: CGN_STORAGE is used by queue triggers (plain connection string)
+CGN_STORAGE=DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://fnstorage:10000/devstoreaccount1;QueueEndpoint=http://fnstorage:10001/devstoreaccount1;TableEndpoint=http://fnstorage:10002/devstoreaccount1;
+# For local dev, CGN_STORAGE_ACCOUNT_NAME is set to the Azurite emulator account name
+CGN_STORAGE_ACCOUNT_NAME=devstoreaccount1
 AzureWebJobsStorage=DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://fnstorage:10000/devstoreaccount1;QueueEndpoint=http://fnstorage:10001/devstoreaccount1;TableEndpoint=http://fnstorage:10002/devstoreaccount1;
 FUNCTIONS_V2_COMPATIBILITY_MODE=true
 

--- a/apps/card-func/package.json
+++ b/apps/card-func/package.json
@@ -47,7 +47,10 @@
   },
   "dependencies": {
     "@azure/cosmos": "^4.2.0",
+    "@azure/data-tables": "^13.3.2",
     "@azure/functions": "^4.11.2",
+    "@azure/identity": "^4.13.1",
+    "@azure/storage-queue": "^12.29.0",
     "@pagopa/io-functions-commons": "^30.0.0",
     "@pagopa/ts-commons": "^13.1.2",
     "applicationinsights": "^3.4.0",

--- a/apps/card-func/src/main.ts
+++ b/apps/card-func/src/main.ts
@@ -6,10 +6,8 @@
  */
 
 import { app } from "@azure/functions";
-import {
-  ExponentialRetryPolicyFilter,
-  createTableService,
-} from "azure-storage";
+import { TableClient } from "@azure/data-tables";
+import { DefaultAzureCredential } from "@azure/identity";
 
 import { EycaAPIClient } from "../clients/eyca";
 import { ServicesAPIClient } from "../clients/services";
@@ -93,27 +91,30 @@ const userEycaCardModel = new UserEycaCardModel(userEycaCardsContainer);
 const queueStorage: QueueStorage = new QueueStorage(config);
 
 // Table Storage
-const tableService = createTableService(config.CGN_STORAGE_CONNECTION_STRING);
+const tableStorageBaseUrl = `https://${config.CGN_STORAGE_ACCOUNT_NAME}.table.core.windows.net`;
+const credential = new DefaultAzureCredential();
 
-const storeCgnExpiration = insertCardExpiration(
-  tableService,
+const cgnExpirationTableClient = new TableClient(
+  tableStorageBaseUrl,
   config.CGN_EXPIRATION_TABLE_NAME,
+  credential,
+  { retryOptions: { maxRetries: 5 } },
 );
 
-const storeEycaExpiration = insertCardExpiration(
-  tableService,
+const eycaExpirationTableClient = new TableClient(
+  tableStorageBaseUrl,
   config.EYCA_EXPIRATION_TABLE_NAME,
+  credential,
+  { retryOptions: { maxRetries: 5 } },
 );
 
-const deleteCgnExpiration = deleteCardExpiration(
-  tableService,
-  config.CGN_EXPIRATION_TABLE_NAME,
-);
+const storeCgnExpiration = insertCardExpiration(cgnExpirationTableClient);
 
-const deleteEycaExpiration = deleteCardExpiration(
-  tableService,
-  config.EYCA_EXPIRATION_TABLE_NAME,
-);
+const storeEycaExpiration = insertCardExpiration(eycaExpirationTableClient);
+
+const deleteCgnExpiration = deleteCardExpiration(cgnExpirationTableClient);
+
+const deleteEycaExpiration = deleteCardExpiration(eycaExpirationTableClient);
 
 // Redis
 const redisClientFactory = getRedisClientFactory(config);
@@ -142,15 +143,13 @@ const deleteEycaCard: DeleteEycaCard = deleteCard(
   config.EYCA_API_PASSWORD,
 );
 
-// Expired card queries (with exponential retry)
+// Expired card queries (with exponential retry configured on TableClient)
 const getExpiredCgnCardUsersFunction = getExpiredCardUsers(
-  tableService.withFilter(new ExponentialRetryPolicyFilter(5)),
-  config.CGN_EXPIRATION_TABLE_NAME,
+  cgnExpirationTableClient,
 );
 
 const getExpiredEycaCardUsersFunction = getExpiredCardUsers(
-  tableService.withFilter(new ExponentialRetryPolicyFilter(5)),
-  config.EYCA_EXPIRATION_TABLE_NAME,
+  eycaExpirationTableClient,
 );
 
 // ---------------------------------------------------------------------------
@@ -260,7 +259,7 @@ app.http("UpsertCgnStatus", {
 // ---------------------------------------------------------------------------
 
 app.storageQueue("CardsDelete_2_ProcessPendingDeleteCgnQueue", {
-  connection: "CGN_STORAGE_CONNECTION_STRING",
+  connection: "CGN_STORAGE",
   handler: processDeleteCgnHandler(
     userCgnModel,
     ServicesAPIClient,
@@ -270,7 +269,7 @@ app.storageQueue("CardsDelete_2_ProcessPendingDeleteCgnQueue", {
 });
 
 app.storageQueue("CardsDelete_3_ProcessPendingDeleteEycaQueue", {
-  connection: "CGN_STORAGE_CONNECTION_STRING",
+  connection: "CGN_STORAGE",
   handler: processDeleteEycaHandler(
     userEycaCardModel,
     deleteEycaExpiration,
@@ -280,7 +279,7 @@ app.storageQueue("CardsDelete_3_ProcessPendingDeleteEycaQueue", {
 });
 
 app.storageQueue("CgnActivation_2_ProcessPendingQueue", {
-  connection: "CGN_STORAGE_CONNECTION_STRING",
+  connection: "CGN_STORAGE",
   handler: processPendingCgnHandler(
     userCgnModel,
     ServicesAPIClient,
@@ -291,7 +290,7 @@ app.storageQueue("CgnActivation_2_ProcessPendingQueue", {
 });
 
 app.storageQueue("CgnActivation_3_ProcessActivatedQueue", {
-  connection: "CGN_STORAGE_CONNECTION_STRING",
+  connection: "CGN_STORAGE",
   handler: processActivatedCgnHandler(
     userCgnModel,
     ServicesAPIClient,
@@ -302,13 +301,13 @@ app.storageQueue("CgnActivation_3_ProcessActivatedQueue", {
 });
 
 app.storageQueue("CgnExpired_2_ProcessExpiredCgnQueue", {
-  connection: "CGN_STORAGE_CONNECTION_STRING",
+  connection: "CGN_STORAGE",
   handler: processExpiredCgnHandler(userCgnModel, queueStorage),
   queueName: "%EXPIRED_CGN_QUEUE_NAME%",
 });
 
 app.storageQueue("EycaActivation_2_ProcessPendingQueue", {
-  connection: "CGN_STORAGE_CONNECTION_STRING",
+  connection: "CGN_STORAGE",
   handler: processPendingEycaHandler(
     userEycaCardModel,
     storeEycaExpiration,
@@ -319,7 +318,7 @@ app.storageQueue("EycaActivation_2_ProcessPendingQueue", {
 });
 
 app.storageQueue("EycaActivation_3_ProcessActivatedQueue", {
-  connection: "CGN_STORAGE_CONNECTION_STRING",
+  connection: "CGN_STORAGE",
   handler: processActivatedEycaHandler(
     userEycaCardModel,
     updateCcdbEycaCard,
@@ -329,13 +328,13 @@ app.storageQueue("EycaActivation_3_ProcessActivatedQueue", {
 });
 
 app.storageQueue("EycaExpired_2_ProcessExpiredEycaQueue", {
-  connection: "CGN_STORAGE_CONNECTION_STRING",
+  connection: "CGN_STORAGE",
   handler: processExpiredEycaHandler(userEycaCardModel, queueStorage),
   queueName: "%EXPIRED_EYCA_QUEUE_NAME%",
 });
 
 app.storageQueue("SendMessage_ProcessMessagesQueue", {
-  connection: "CGN_STORAGE_CONNECTION_STRING",
+  connection: "CGN_STORAGE",
   handler: sendMessageHandler(
     GetProfile(ServicesAPIClient),
     SendMessage(MessagesAPIClient),

--- a/apps/card-func/utils/__tests__/table_storage.test.ts
+++ b/apps/card-func/utils/__tests__/table_storage.test.ts
@@ -1,135 +1,81 @@
 // eslint-disable @typescript-eslint/no-explicit-any
 
-import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
+import { RestError } from "@azure/data-tables";
 import { pipe } from "fp-ts/lib/function";
+import * as E from "fp-ts/lib/Either";
 import * as TE from "fp-ts/lib/TaskEither";
 import { deleteCardExpiration, insertCardExpiration } from "../table_storage";
 import { aFiscalCode, now } from "../../__mocks__/mock";
 
-const aCardExpirationTableName = "TableName" as NonEmptyString;
+const deleteEntityMock = jest.fn().mockResolvedValue(undefined);
+const upsertEntityMock = jest.fn().mockResolvedValue(undefined);
 
-const aSuccessfulServiceResponse = {
-  isSuccessful: true,
-  statusCode: 200
-};
-
-const aNotFoundServiceResponse = {
-  isSuccessful: false,
-  statusCode: 404
-};
-
-const anErrorServiceResponse = {
-  isSuccessful: false,
-  statusCode: 500
-};
-const deleteEntityMock = jest
-  .fn()
-  .mockImplementation((_, __, cb) => cb(null, aSuccessfulServiceResponse));
-
-const insertOrReplaceEntityMock = jest
-  .fn()
-  .mockImplementation((_, __, cb) => cb(null, {}));
-const tableStorageMock = {
+const tableClientMock = {
   deleteEntity: deleteEntityMock,
-  insertOrReplaceEntity: insertOrReplaceEntityMock
+  upsertEntity: upsertEntityMock,
 } as any;
 
+beforeEach(() => {
+  jest.clearAllMocks();
+  deleteEntityMock.mockResolvedValue(undefined);
+  upsertEntityMock.mockResolvedValue(undefined);
+});
+
 describe("deleteCardExpiration", () => {
-  it("should return a success response if delete succeed", async () => {
-    const deleteExpirationTask = deleteCardExpiration(
-      tableStorageMock,
-      aCardExpirationTableName
-    );
-    await pipe(
-      deleteExpirationTask(aFiscalCode, now),
-      TE.bimap(
-        _ => fail(),
-        value => expect(value).toEqual(aSuccessfulServiceResponse)
-      )
+  it("should succeed if deleteEntity resolves", async () => {
+    const result = await deleteCardExpiration(tableClientMock)(
+      aFiscalCode,
+      now,
     )();
+    expect(E.isRight(result)).toBe(true);
   });
 
-  it("should return a response if target tuple is not found", async () => {
-    deleteEntityMock.mockImplementationOnce((_, __, cb) =>
-      cb(null, aNotFoundServiceResponse)
-    );
-    const deleteExpirationTask = deleteCardExpiration(
-      tableStorageMock,
-      aCardExpirationTableName
-    );
-    await pipe(
-      deleteExpirationTask(aFiscalCode, now),
-      TE.bimap(
-        _ => fail(),
-        value => expect(value).toEqual(aNotFoundServiceResponse)
-      )
+  it("should succeed (not error) if entity is not found (404)", async () => {
+    const notFoundError = new RestError("Not Found", {
+      statusCode: 404,
+      code: "ResourceNotFound",
+    });
+    deleteEntityMock.mockRejectedValueOnce(notFoundError);
+    const result = await deleteCardExpiration(tableClientMock)(
+      aFiscalCode,
+      now,
     )();
+    expect(E.isRight(result)).toBe(true);
   });
 
-  it("should return an error if something else fails during delete operation", async () => {
-    deleteEntityMock.mockImplementationOnce((_, __, cb) =>
-      cb(null, anErrorServiceResponse)
-    );
-    const deleteExpirationTask = deleteCardExpiration(
-      tableStorageMock,
-      aCardExpirationTableName
-    );
-    await pipe(
-      deleteExpirationTask(aFiscalCode, now),
-      TE.bimap(
-        _ => expect(_).toBeDefined(),
-        () => fail()
-      )
+  it("should return an error if deleteEntity throws a non-404 error", async () => {
+    deleteEntityMock.mockRejectedValueOnce(new Error("Cannot delete tuple"));
+    const result = await deleteCardExpiration(tableClientMock)(
+      aFiscalCode,
+      now,
     )();
-  });
-
-  it("should return an error if delete operation raise an error", async () => {
-    deleteEntityMock.mockImplementationOnce((_, __, cb) =>
-      cb(new Error("Cannot delete tuple"), null)
-    );
-    const deleteExpirationTask = deleteCardExpiration(
-      tableStorageMock,
-      aCardExpirationTableName
-    );
-    await pipe(
-      deleteExpirationTask(aFiscalCode, now),
-      TE.bimap(
-        _ => expect(_).toBeDefined(),
-        () => fail()
-      )
-    )();
+    expect(E.isLeft(result)).toBe(true);
+    if (E.isLeft(result)) {
+      expect(result.left).toBeDefined();
+    }
   });
 });
 
 describe("insertCardExpiration", () => {
-  it("should return a success response if insert succeed", async () => {
-    const insertExpirationTask = insertCardExpiration(
-      tableStorageMock,
-      aCardExpirationTableName
-    );
-    await pipe(
-      insertExpirationTask(aFiscalCode, now, now),
-      TE.bimap(
-        _ => fail(),
-        value => expect(value).toEqual({})
-      )
+  it("should succeed if upsertEntity resolves", async () => {
+    const result = await insertCardExpiration(tableClientMock)(
+      aFiscalCode,
+      now,
+      now,
     )();
+    expect(E.isRight(result)).toBe(true);
   });
 
-  it("should return an error if insert fails", async () => {
-    insertOrReplaceEntityMock.mockImplementationOnce((_, __, cb) =>
-      cb(new Error("Cannot insert entity"), null)
-    );
-    const insertExpirationTask = insertCardExpiration(
-      tableStorageMock,
-      aCardExpirationTableName
-    );
-    await pipe(
-      insertExpirationTask(aFiscalCode, now, now),
-      TE.bimap(
-        _ => expect(_).toBeDefined(),
-        () => fail()
-      )
+  it("should return an error if upsertEntity throws", async () => {
+    upsertEntityMock.mockRejectedValueOnce(new Error("Cannot insert entity"));
+    const result = await insertCardExpiration(tableClientMock)(
+      aFiscalCode,
+      now,
+      now,
     )();
+    expect(E.isLeft(result)).toBe(true);
+    if (E.isLeft(result)) {
+      expect(result.left).toBeDefined();
+    }
   });
 });

--- a/apps/card-func/utils/card_expiration.ts
+++ b/apps/card-func/utils/card_expiration.ts
@@ -1,5 +1,5 @@
+import { TableClient } from "@azure/data-tables";
 import { FiscalCode } from "@pagopa/ts-commons/lib/strings";
-import { TableService } from "azure-storage";
 import * as E from "fp-ts/lib/Either";
 import * as TE from "fp-ts/lib/TaskEither";
 import { pipe } from "fp-ts/lib/function";
@@ -29,9 +29,9 @@ const withExpiredCardRowFromEntry =
   (f: (s: ExpiredCardRowKey) => void) =>
   (e: TableEntry): void =>
     f({
-      activationDate: e.ActivationDate._,
-      expirationDate: e.ExpirationDate._,
-      fiscalCode: e.RowKey._,
+      activationDate: e.ActivationDate as unknown as Timestamp,
+      expirationDate: e.ExpirationDate as unknown as Timestamp,
+      fiscalCode: e.rowKey as FiscalCode,
     });
 
 /**
@@ -52,16 +52,14 @@ export type GetExpiredCardUserFunction = ReturnType<typeof getExpiredCardUsers>;
 
 export const getExpiredCardUsers =
   (
-    tableService: TableService,
-    expiredCardTableName: string,
+    tableClient: TableClient,
   ): ((
     refDate: string,
   ) => TE.TaskEither<Error, readonly ExpiredCardRowKey[]>) =>
   (refDate: string) =>
-    // get a function that can query the expired cgns table
+    // get a function that can query the expired cards table
     pipe(
-      TE.of(getPagedQuery(tableService, expiredCardTableName)),
-      TE.map((pagedQuery) => pagedQuery(queryFilterForKey(`${refDate}`))),
+      TE.of(getPagedQuery(tableClient)(queryFilterForKey(refDate))),
       TE.chain((cgnExpirationQuery) =>
         pipe(
           TE.tryCatch(() => queryUsers(cgnExpirationQuery), E.toError),

--- a/apps/card-func/utils/config.ts
+++ b/apps/card-func/utils/config.ts
@@ -59,7 +59,7 @@ export const IConfig = t.intersection([
 
     CGN_EXPIRATION_TABLE_NAME: NonEmptyString,
 
-    CGN_STORAGE_CONNECTION_STRING: NonEmptyString,
+    CGN_STORAGE_ACCOUNT_NAME: NonEmptyString,
     CGN_UPPER_BOUND_AGE: NonNegativeInteger,
     COSMOSDB_CGN_DATABASE_NAME: NonEmptyString,
 

--- a/apps/card-func/utils/healthcheck.ts
+++ b/apps/card-func/utils/healthcheck.ts
@@ -1,12 +1,8 @@
+import { QueueServiceClient } from "@azure/storage-queue";
+import { TableServiceClient } from "@azure/data-tables";
+import { DefaultAzureCredential } from "@azure/identity";
 import { CosmosClient } from "@azure/cosmos";
 import { readableReport } from "@pagopa/ts-commons/lib/reporters";
-import {
-  common as azurestorageCommon,
-  createBlobService,
-  createFileService,
-  createQueueService,
-  createTableService,
-} from "azure-storage";
 import { sequenceT } from "fp-ts/lib/Apply";
 import * as A from "fp-ts/lib/Array";
 import * as E from "fp-ts/lib/Either";
@@ -96,46 +92,42 @@ export const checkAzureCosmosDbHealth = (
   );
 
 /**
- * Check the application can connect to an Azure Storage
+ * Check the application can connect to Azure Storage using identity-based access.
  *
- * @param connStr connection string for the storage
+ * @param accountName storage account name
  *
  * @returns either true or an array of error messages
  */
 export const checkAzureStorageHealth = (
-  connStr: string,
+  accountName: string,
 ): HealthCheck<"AzureStorage"> => {
+  const credential = new DefaultAzureCredential();
   const applicativeValidation = TE.getApplicativeTaskValidation(
     T.ApplicativePar,
     RA.getSemigroup<HealthProblem<"AzureStorage">>(),
   );
 
-  // try to instantiate a client for each product of azure storage
+  const checkQueue = TE.tryCatch(async () => {
+    const client = new QueueServiceClient(
+      `https://${accountName}.queue.core.windows.net`,
+      credential,
+    );
+    await client.getProperties();
+  }, toHealthProblems("AzureStorage"));
+
+  const checkTable = TE.tryCatch(async () => {
+    const client = new TableServiceClient(
+      `https://${accountName}.table.core.windows.net`,
+      credential,
+    );
+    // list one table to verify connectivity
+    for await (const _ of client.listTables()) {
+      break;
+    }
+  }, toHealthProblems("AzureStorage"));
+
   return pipe(
-    [
-      createBlobService,
-      createFileService,
-      createQueueService,
-      createTableService,
-    ]
-      // for each, create a task that wraps getServiceProperties
-      .map((createService) =>
-        TE.tryCatch(
-          () =>
-            new Promise<azurestorageCommon.models.ServicePropertiesResult.ServiceProperties>(
-              (resolve, reject) =>
-                createService(connStr).getServiceProperties((err, result) => {
-                  // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-                  err
-                    ? reject(err.message.replace(/\n/gim, " ")) // avoid newlines
-                    : resolve(result);
-                }),
-            ),
-          toHealthProblems("AzureStorage"),
-        ),
-      ),
-    // run each taskEither and gather validation errors from each one of them, if any
-    A.sequence(applicativeValidation),
+    sequenceT(applicativeValidation)(checkQueue, checkTable),
     TE.map(() => true),
   );
 };
@@ -185,7 +177,7 @@ export const checkApplicationHealth = (): HealthCheck<ProblemSource, true> => {
     TE.chain((config) =>
       // run each taskEither and collect validation errors from each one of them, if any
       sequenceT(applicativeValidation)(
-        checkAzureStorageHealth(config.CGN_STORAGE_CONNECTION_STRING),
+        checkAzureStorageHealth(config.CGN_STORAGE_ACCOUNT_NAME),
         checkRedisConnection(config),
       ),
     ),

--- a/apps/card-func/utils/models.ts
+++ b/apps/card-func/utils/models.ts
@@ -5,7 +5,7 @@ import {
   ResponseErrorNotFound,
 } from "@pagopa/ts-commons/lib/responses";
 import { FiscalCode, NonEmptyString } from "@pagopa/ts-commons/lib/strings";
-import { QueueService } from "azure-storage";
+import { QueueClient } from "@azure/storage-queue";
 import * as TE from "fp-ts/lib/TaskEither";
 import { pipe } from "fp-ts/lib/function";
 
@@ -51,20 +51,16 @@ export const retrieveUserEycaCard = (
  * Enqueue an EYCA activation's process
  */
 export const getEnqueueEycaActivation = (
-  queueService: QueueService,
-  queueName: NonEmptyString,
-): ((
-  input: Record<string, string>,
-) => TE.TaskEither<Error, QueueService.QueueMessageResult>) => {
-  const createMessage = TE.taskify(
-    queueService.createMessage.bind(queueService),
-  );
-  return (
-    input: Record<string, string>,
-  ): TE.TaskEither<Error, QueueService.QueueMessageResult> => {
+  queueClient: QueueClient,
+): ((input: Record<string, string>) => TE.TaskEither<Error, boolean>) => {
+  return (input: Record<string, string>): TE.TaskEither<Error, boolean> => {
     // see https://github.com/Azure/Azure-Functions/issues/1091
     const message = Buffer.from(JSON.stringify(input)).toString("base64");
-    return createMessage(queueName, message);
+    return TE.tryCatch(async () => {
+      await queueClient.createIfNotExists();
+      await queueClient.sendMessage(message);
+      return true;
+    }, (e) => e instanceof Error ? e : new Error(String(e)));
   };
 };
 

--- a/apps/card-func/utils/queue.ts
+++ b/apps/card-func/utils/queue.ts
@@ -1,4 +1,5 @@
-import { QueueService } from "azure-storage";
+import { QueueClient, QueueServiceClient } from "@azure/storage-queue";
+import { DefaultAzureCredential } from "@azure/identity";
 import * as E from "fp-ts/lib/Either";
 import * as TE from "fp-ts/lib/TaskEither";
 import { pipe } from "fp-ts/lib/function";
@@ -13,81 +14,67 @@ import {
 import { toBase64 } from "./base64";
 import { IConfig } from "./config";
 
+const getQueueServiceClient = (accountName: string): QueueServiceClient =>
+  new QueueServiceClient(
+    `https://${accountName}.queue.core.windows.net`,
+    new DefaultAzureCredential(),
+  );
+
 export class QueueStorage {
   config: IConfig;
-  createMessage = (queueName: string, message: string) =>
-    TE.tryCatch(
-      async () =>
-        new Promise<boolean>((resolve, reject) =>
-          this.queueService.createMessage(queueName, message, (error: Error) =>
-            error ? reject(error) : resolve(true),
-          ),
-        ),
-      E.toError,
-    );
+  queueServiceClient: QueueServiceClient;
 
-  createQueue = (queueName: string) =>
-    TE.tryCatch(
-      () =>
-        new Promise<boolean>((resolve, reject) =>
-          this.queueService.createQueueIfNotExists(queueName, (error: Error) =>
-            error ? reject(error) : resolve(true),
-          ),
-        ),
-      E.toError,
+  constructor(config: IConfig) {
+    this.config = config;
+    this.queueServiceClient = getQueueServiceClient(
+      config.CGN_STORAGE_ACCOUNT_NAME,
     );
+  }
+
+  private getQueueClient = (queueName: string): QueueClient =>
+    this.queueServiceClient.getQueueClient(queueName);
+
+  createMessage = (queueName: string, message: string) =>
+    TE.tryCatch(async () => {
+      const queueClient = this.getQueueClient(queueName);
+      await queueClient.createIfNotExists();
+      await queueClient.sendMessage(message);
+      return true;
+    }, E.toError);
 
   enqueueActivatedCGNMessage = (message: CardActivatedMessage) =>
-    this.enqueueMessage(
-      this.config.ACTIVATED_CGN_QUEUE_NAME,
-      toBase64(message),
-    );
+    this.createMessage(this.config.ACTIVATED_CGN_QUEUE_NAME, toBase64(message));
 
   enqueueActivatedEYCAMessage = (message: CardActivatedMessage) =>
-    this.enqueueMessage(
+    this.createMessage(
       this.config.ACTIVATED_EYCA_QUEUE_NAME,
       toBase64(message),
     );
 
   enqueueExpiredCGNMessage = (message: CardExpiredMessage) =>
-    this.enqueueMessage(this.config.EXPIRED_CGN_QUEUE_NAME, toBase64(message));
+    this.createMessage(this.config.EXPIRED_CGN_QUEUE_NAME, toBase64(message));
 
   enqueueExpiredEYCAMessage = (message: CardExpiredMessage) =>
-    this.enqueueMessage(this.config.EXPIRED_EYCA_QUEUE_NAME, toBase64(message));
-
-  enqueueMessage = (queueName: string, message: string) =>
-    pipe(
-      this.createQueue(queueName),
-      TE.chain(() => this.createMessage(queueName, message)),
-    );
+    this.createMessage(this.config.EXPIRED_EYCA_QUEUE_NAME, toBase64(message));
 
   enqueueMessageToSendMessage = (message: MessageToSendMessage) =>
-    this.enqueueMessage(this.config.MESSAGES_QUEUE_NAME, toBase64(message));
+    this.createMessage(this.config.MESSAGES_QUEUE_NAME, toBase64(message));
 
   enqueuePendingCGNMessage = (message: CardPendingMessage) =>
-    this.enqueueMessage(this.config.PENDING_CGN_QUEUE_NAME, toBase64(message));
+    this.createMessage(this.config.PENDING_CGN_QUEUE_NAME, toBase64(message));
 
   enqueuePendingDeleteCGNMessage = (message: CardPendingDeleteMessage) =>
-    this.enqueueMessage(
+    this.createMessage(
       this.config.PENDING_DELETE_CGN_QUEUE_NAME,
       toBase64(message),
     );
 
   enqueuePendingDeleteEYCAMessage = (message: CardPendingDeleteMessage) =>
-    this.enqueueMessage(
+    this.createMessage(
       this.config.PENDING_DELETE_EYCA_QUEUE_NAME,
       toBase64(message),
     );
 
   enqueuePendingEYCAMessage = (message: CardPendingMessage) =>
-    this.enqueueMessage(this.config.PENDING_EYCA_QUEUE_NAME, toBase64(message));
-
-  queueService: QueueService;
-
-  constructor(config: IConfig) {
-    this.config = config;
-    this.queueService = new QueueService(
-      this.config.CGN_STORAGE_CONNECTION_STRING,
-    );
-  }
+    this.createMessage(this.config.PENDING_EYCA_QUEUE_NAME, toBase64(message));
 }

--- a/apps/card-func/utils/table_storage.ts
+++ b/apps/card-func/utils/table_storage.ts
@@ -1,15 +1,13 @@
-import { FiscalCode, NonEmptyString } from "@pagopa/ts-commons/lib/strings";
+import { DefaultAzureCredential } from "@azure/identity";
+import { RestError } from "@azure/data-tables";
 import {
-  ServiceResponse,
-  TableQuery,
-  TableService,
-  TableUtilities,
-} from "azure-storage";
+  TableClient,
+  TableEntityResult,
+} from "@azure/data-tables";
+import { FiscalCode, NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import * as date_fns from "date-fns";
 import * as E from "fp-ts/lib/Either";
-import * as O from "fp-ts/lib/Option";
 import * as TE from "fp-ts/lib/TaskEither";
-import { pipe } from "fp-ts/lib/function";
 
 import { Timestamp } from "../generated/definitions/Timestamp";
 
@@ -17,88 +15,57 @@ import { Timestamp } from "../generated/definitions/Timestamp";
  * A minimal Youth Card storage table Entry
  */
 export type TableEntry = Readonly<{
-  readonly ActivationDate: Readonly<{
-    readonly _: Timestamp;
-  }>;
-  readonly ExpirationDate: Readonly<{
-    readonly _: Timestamp;
-  }>;
-  readonly RowKey: Readonly<{
-    readonly _: FiscalCode;
-  }>;
+  readonly ActivationDate: Date;
+  readonly ExpirationDate: Date;
+  readonly rowKey: FiscalCode;
 }>;
 
-/**
- * A function that returns a page of query results given a pagination token
- *
- * @see https://docs.microsoft.com/en-us/rest/api/storageservices/query-timeout-and-pagination
- */
-export type PagedQuery = (
-  currentToken: TableService.TableContinuationToken,
-) => Promise<E.Either<Error, TableService.QueryEntitiesResult<TableEntry>>>;
+export type PagedQuery = () => AsyncIterableIterator<readonly TableEntry[]>;
 
 /**
- * Returns a paged query function for a certain query on a storage table
+ * Returns a TableClient using managed identity for the given storage account and table.
+ */
+export const getTableClient = (
+  accountName: string,
+  tableName: string,
+): TableClient =>
+  new TableClient(
+    `https://${accountName}.table.core.windows.net`,
+    tableName,
+    new DefaultAzureCredential(),
+    { retryOptions: { maxRetries: 5 } },
+  );
+
+/**
+ * Returns a paged query function that iterates over all entities matching the filter.
  */
 export const getPagedQuery =
-  (tableService: TableService, table: string) =>
-  (tableQuery: TableQuery): PagedQuery =>
-  (
-    currentToken,
-  ): Promise<E.Either<Error, TableService.QueryEntitiesResult<TableEntry>>> =>
-    new Promise((resolve) =>
-      tableService.queryEntities(
-        table,
-        tableQuery,
-        currentToken,
-        (
-          error: Error,
-          result: TableService.QueryEntitiesResult<TableEntry>,
-          response: ServiceResponse,
-        ) => resolve(response.isSuccessful ? E.right(result) : E.left(error)),
-      ),
-    );
+  (tableClient: TableClient) =>
+  (filter: string): PagedQuery =>
+    async function* (): AsyncIterableIterator<readonly TableEntry[]> {
+      for await (const page of tableClient
+        .listEntities<TableEntry>({ queryOptions: { filter } })
+        .byPage()) {
+        yield page as readonly TableEntry[];
+      }
+    };
 
 /**
- * Iterates over all pages of entries returned by the provided paged query
- * function.
+ * Iterates over all pages of entries returned by the provided paged query function.
  *
  * @throws Exception on query failure
  */
 export async function* iterateOnPages(
   pagedQuery: PagedQuery,
 ): AsyncIterableIterator<readonly TableEntry[]> {
-  let token = undefined as unknown as TableService.TableContinuationToken;
-  do {
-    // query for a page of entries
-    const errorOrResults = await pagedQuery(token);
-    if (E.isLeft(errorOrResults)) {
-      // throw an exception in case of error
-      throw errorOrResults.left;
-    }
-    // call the async callback with the current page of entries
-    const results = errorOrResults.right;
-    yield results.entries;
-    // update the continuation token, the loop will continue until
-    // the token is defined
-    token = pipe(
-      results.continuationToken,
-      O.fromNullable,
-      O.getOrElse(
-        () => undefined as unknown as TableService.TableContinuationToken,
-      ),
-    );
-  } while (token !== undefined && token !== null);
+  yield* pagedQuery();
 }
 
 /**
- * Returns a query filter to get the RowKey(s) for all entries that have the
- * provided partition key
+ * Returns an OData filter expression to select all entries for the provided partition key.
  */
-export const queryFilterForKey = (partitionKey: string): TableQuery =>
-  new TableQuery()
-    .select("RowKey", "ActivationDate", "ExpirationDate")
-    .where("PartitionKey == ?", partitionKey);
+export const queryFilterForKey = (partitionKey: string): string =>
+  `PartitionKey eq '${partitionKey}'`;
 
 /**
  * Store a card expiration into `cardExpirationTableName` table
@@ -107,70 +74,56 @@ export type StoreCardExpirationFunction = (
   fiscalCode: FiscalCode,
   activationDate: Date,
   expirationDate: Date,
-) => TE.TaskEither<Error, TableService.EntityMetadata>;
+) => TE.TaskEither<Error, void>;
 
 export const insertCardExpiration =
-  (
-    tableService: TableService,
-    cardExpirationTableName: NonEmptyString,
-  ): StoreCardExpirationFunction =>
+  (tableClient: TableClient): StoreCardExpirationFunction =>
   (
     fiscalCode: FiscalCode,
     activationDate: Date,
     expirationDate: Date,
-  ): TE.TaskEither<Error, TableService.EntityMetadata> => {
-    const eg = TableUtilities.entityGenerator;
-    return TE.taskify<Error, TableService.EntityMetadata>((cb) =>
-      tableService.insertOrReplaceEntity(
-        cardExpirationTableName,
-        {
-          ActivationDate: eg.DateTime(activationDate),
-          ExpirationDate: eg.DateTime(expirationDate),
-          PartitionKey: eg.String(
-            date_fns.format(expirationDate, "yyyy-MM-dd"),
-          ),
-          RowKey: eg.String(fiscalCode),
-        },
-        cb,
-      ),
-    )();
-  };
+  ): TE.TaskEither<Error, void> =>
+    TE.tryCatch(
+      async () => {
+        await tableClient.upsertEntity(
+          {
+            partitionKey: date_fns.format(expirationDate, "yyyy-MM-dd"),
+            rowKey: fiscalCode,
+            ActivationDate: activationDate,
+            ExpirationDate: expirationDate,
+          },
+          "Replace",
+        );
+      },
+      E.toError,
+    );
 
 /**
- * Delete a card expiration into `cardExpirationTableName` table
+ * Delete a card expiration from `cardExpirationTableName` table
  */
 export type DeleteCardExpirationFunction = (
   fiscalCode: FiscalCode,
   expirationDate: Date,
-) => TE.TaskEither<Error, ServiceResponse>;
+) => TE.TaskEither<Error, void>;
 
 export const deleteCardExpiration =
-  (
-    tableService: TableService,
-    cardExpirationTableName: NonEmptyString,
-  ): DeleteCardExpirationFunction =>
+  (tableClient: TableClient): DeleteCardExpirationFunction =>
   (
     fiscalCode: FiscalCode,
     expirationDate: Date,
-  ): TE.TaskEither<Error, ServiceResponse> => {
-    const eg = TableUtilities.entityGenerator;
-    return TE.tryCatch(
-      () =>
-        new Promise((resolve, reject) =>
-          tableService.deleteEntity(
-            cardExpirationTableName,
-            {
-              PartitionKey: eg.String(
-                date_fns.format(expirationDate, "yyyy-MM-dd"),
-              ),
-              RowKey: eg.String(fiscalCode),
-            },
-            (error: Error | null, response: ServiceResponse | null) =>
-              (error || !response?.isSuccessful) && response?.statusCode !== 404
-                ? reject(error?.message || "Unsuccessful response from storage")
-                : resolve(response),
-          ),
-        ),
+  ): TE.TaskEither<Error, void> =>
+    TE.tryCatch(
+      async () => {
+        try {
+          await tableClient.deleteEntity(
+            date_fns.format(expirationDate, "yyyy-MM-dd"),
+            fiscalCode,
+          );
+        } catch (e) {
+          // 404 is acceptable — entity may not exist
+          if (e instanceof RestError && e.statusCode === 404) return;
+          throw e;
+        }
+      },
       E.toError,
     );
-  };

--- a/apps/support-func/package.json
+++ b/apps/support-func/package.json
@@ -41,6 +41,7 @@
   "dependencies": {
     "@azure/cosmos": "^4.2.0",
     "@azure/functions": "^4.0.0",
+    "@azure/identity": "^4.13.1",
     "@pagopa/io-functions-commons": "^30.0.0",
     "@pagopa/ts-commons": "^13.1.2",
     "applicationinsights": "^3.4.0",

--- a/apps/support-func/utils/config.ts
+++ b/apps/support-func/utils/config.ts
@@ -18,15 +18,9 @@ export const IConfig = t.interface({
   APPINSIGHTS_SAMPLING_PERCENTAGE: NonEmptyString,
   APPLICATIONINSIGHTS_CONNECTION_STRING: NonEmptyString,
 
-  CGN_EXPIRATION_TABLE_NAME: NonEmptyString,
-
-  CGN_STORAGE_CONNECTION_STRING: NonEmptyString,
-
   COSMOSDB_CGN_DATABASE_NAME: NonEmptyString,
   COSMOSDB_CGN_KEY: NonEmptyString,
   COSMOSDB_CGN_URI: NonEmptyString,
-
-  EYCA_EXPIRATION_TABLE_NAME: NonEmptyString,
 
   isProduction: t.boolean,
 });

--- a/apps/support-func/utils/healthcheck.ts
+++ b/apps/support-func/utils/healthcheck.ts
@@ -1,13 +1,5 @@
 import { readableReport } from "@pagopa/ts-commons/lib/reporters";
-import {
-  common as azurestorageCommon,
-  createBlobService,
-  createFileService,
-  createQueueService,
-  createTableService,
-} from "azure-storage";
 import { sequenceT } from "fp-ts/lib/Apply";
-import * as A from "fp-ts/lib/Array";
 import * as E from "fp-ts/lib/Either";
 import * as RA from "fp-ts/lib/ReadonlyArray";
 import * as T from "fp-ts/lib/Task";
@@ -18,7 +10,7 @@ import fetch from "node-fetch";
 import { IConfig, getConfig } from "./config";
 import { getCosmosDbClientInstance } from "./cosmosdb";
 
-type ProblemSource = "AzureCosmosDB" | "AzureStorage" | "Config" | "Url";
+type ProblemSource = "AzureCosmosDB" | "Config" | "Url";
 export type HealthProblem<S extends ProblemSource> = {
   // eslint-disable-next-line @typescript-eslint/naming-convention
   readonly __source: S;
@@ -88,51 +80,6 @@ export const checkAzureCosmosDbHealth = (
   );
 
 /**
- * Check the application can connect to an Azure Storage
- *
- * @param connStr connection string for the storage
- *
- * @returns either true or an array of error messages
- */
-export const checkAzureStorageHealth = (
-  connStr: string,
-): HealthCheck<"AzureStorage"> => {
-  const applicativeValidation = TE.getApplicativeTaskValidation(
-    T.ApplicativePar,
-    RA.getSemigroup<HealthProblem<"AzureStorage">>(),
-  );
-
-  // try to instantiate a client for each product of azure storage
-  return pipe(
-    [
-      createBlobService,
-      createFileService,
-      createQueueService,
-      createTableService,
-    ]
-      // for each, create a task that wraps getServiceProperties
-      .map((createService) =>
-        TE.tryCatch(
-          () =>
-            new Promise<azurestorageCommon.models.ServicePropertiesResult.ServiceProperties>(
-              (resolve, reject) =>
-                createService(connStr).getServiceProperties((err, result) => {
-                  // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-                  err
-                    ? reject(err.message.replace(/\n/gim, " ")) // avoid newlines
-                    : resolve(result);
-                }),
-            ),
-          toHealthProblems("AzureStorage"),
-        ),
-      ),
-    // run each taskEither and gather validation errors from each one of them, if any
-    A.sequence(applicativeValidation),
-    TE.map(() => true),
-  );
-};
-
-/**
  * Check a url is reachable
  *
  * @param url url to connect with
@@ -163,7 +110,6 @@ export const checkApplicationHealth = (): HealthCheck<ProblemSource, true> => {
     TE.chain((config) =>
       // run each taskEither and collect validation errors from each one of them, if any
       sequenceT(applicativeValidation)(
-        checkAzureStorageHealth(config.CGN_STORAGE_CONNECTION_STRING),
         checkAzureCosmosDbHealth(
           config.COSMOSDB_CGN_URI,
           config.COSMOSDB_CGN_KEY,

--- a/infra-io/resources/_modules/function_app_card/locals.tf
+++ b/infra-io/resources/_modules/function_app_card/locals.tf
@@ -16,7 +16,11 @@ locals {
       COSMOSDB_CGN_KEY           = var.cosmosdb_cgn_key
       COSMOSDB_CGN_DATABASE_NAME = var.cosmosdb_cgn_database_name
 
-      // STORAGE
+      // STORAGE (RBAC - identity-based connection)
+      CGN_STORAGE__serviceUri  = "https://${var.storage_cgn_account_name}.queue.core.windows.net"
+      CGN_STORAGE_ACCOUNT_NAME = var.storage_cgn_account_name
+
+      // STORAGE (legacy connection string - kept for backward compat, removed in a following PR)
       CGN_STORAGE_CONNECTION_STRING = var.storage_cgn_connection_string
 
       // TABLE STORAGE

--- a/infra-io/resources/_modules/function_app_card/variables.tf
+++ b/infra-io/resources/_modules/function_app_card/variables.tf
@@ -126,6 +126,11 @@ variable "cosmosdb_cgn_database_name" {
   description = "Database name for CGN cosmosdb"
 }
 
+variable "storage_cgn_account_name" {
+  type        = string
+  description = "CGN storage account name (used for identity-based RBAC connections)"
+}
+
 variable "storage_cgn_connection_string" {
   type        = string
   description = "CGN storage connection key"

--- a/infra-io/resources/prod/func_card.tf
+++ b/infra-io/resources/prod/func_card.tf
@@ -32,6 +32,7 @@ module "functions_cgn_card_02" {
   cosmosdb_cgn_key           = data.azurerm_key_vault_secret.cosmosdb_cgn_key.value
   cosmosdb_cgn_database_name = "db"
 
+  storage_cgn_account_name      = data.azurerm_storage_account.storage_cgn_itn.name
   storage_cgn_connection_string = data.azurerm_key_vault_secret.storage_cgn_connection_string.value
 
   table_cgn_expiration  = "cardexpiration"

--- a/infra-io/resources/prod/iam.tf
+++ b/infra-io/resources/prod/iam.tf
@@ -41,3 +41,25 @@ module "appsvc_principal_role_assignments" {
     }
   ]
 }
+
+resource "azurerm_role_assignment" "card_func_storage_queue_contributor" {
+  for_each = toset([
+    module.functions_cgn_card_02.function_app_cgn_card.principal_id,
+    module.functions_cgn_card_02.function_app_cgn_card.staging_principal_id,
+  ])
+
+  scope                = data.azurerm_storage_account.storage_cgn_itn.id
+  role_definition_name = "Storage Queue Data Contributor"
+  principal_id         = each.value
+}
+
+resource "azurerm_role_assignment" "card_func_storage_table_contributor" {
+  for_each = toset([
+    module.functions_cgn_card_02.function_app_cgn_card.principal_id,
+    module.functions_cgn_card_02.function_app_cgn_card.staging_principal_id,
+  ])
+
+  scope                = data.azurerm_storage_account.storage_cgn_itn.id
+  role_definition_name = "Storage Table Data Contributor"
+  principal_id         = each.value
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,9 +45,18 @@ importers:
       '@azure/cosmos':
         specifier: ^4.2.0
         version: 4.5.1
+      '@azure/data-tables':
+        specifier: ^13.3.2
+        version: 13.3.2
       '@azure/functions':
         specifier: ^4.11.2
         version: 4.11.2
+      '@azure/identity':
+        specifier: ^4.13.1
+        version: 4.13.1
+      '@azure/storage-queue':
+        specifier: ^12.29.0
+        version: 12.29.0
       '@pagopa/io-functions-commons':
         specifier: ^30.0.0
         version: 30.0.0(@azure/functions@4.11.2)(@pagopa/ts-commons@13.1.2(fp-ts@2.16.11)(io-ts@2.2.22(fp-ts@2.16.11)))(express@4.21.2)(fp-ts@2.16.11)(io-ts@2.2.22(fp-ts@2.16.11))
@@ -303,6 +312,9 @@ importers:
       '@azure/functions':
         specifier: ^4.0.0
         version: 4.8.0
+      '@azure/identity':
+        specifier: ^4.13.1
+        version: 4.13.1
       '@pagopa/io-functions-commons':
         specifier: ^30.0.0
         version: 30.0.0(@azure/functions@4.8.0)(@pagopa/ts-commons@13.1.2(fp-ts@2.16.11)(io-ts@2.2.22(fp-ts@2.16.11)))(express@4.21.2)(fp-ts@2.16.11)(io-ts@2.2.22(fp-ts@2.16.11))
@@ -450,9 +462,9 @@ packages:
     resolution: {integrity: sha512-fbuXnfsjkVKNKG/xtIM+rQSU9AiWB3Qah8L6cHFFUX7t0P6jXYWSwI3FO/NxadHtkISb/WiBCQ7PJsUveM0XMg==}
     engines: {node: '>=20.0.0'}
 
-  '@azure/data-tables@13.3.1':
-    resolution: {integrity: sha512-jGk1s1SbAfy39zxArNn4HAmycmHF/+XtYYRZ6kakayxJNQeeuacSkLUioezOZIVI01i3Yvr4xzTMuKZpdKXf1Q==}
-    engines: {node: '>=18.0.0'}
+  '@azure/data-tables@13.3.2':
+    resolution: {integrity: sha512-PZ8e4SnCpTQEbQ1P+CK6NR7Vhb86Jw1S1qJi2IcF1ij4qiPX2b4vIemwNPkYg/gZGMqKbxkPvGRpRmEbBYdXuA==}
+    engines: {node: '>=20.0.0'}
 
   '@azure/functions-extensions-base@0.2.0':
     resolution: {integrity: sha512-ncCkHBNQYJa93dBIh+toH0v1iSgCzSo9tr94s6SMBe7DPWREkaWh8cq33A5P4rPSFX1g5W+3SPvIzDr/6/VOWQ==}
@@ -469,8 +481,8 @@ packages:
     resolution: {integrity: sha512-LNtl3xZNE40vE7+SIST+GYQX5cnnI1M65fXPi26l9XCdPakuQrz54lHv+qQQt1GG5JbqLfQk75iM7A6Y9O+2dQ==}
     engines: {node: '>=18.0'}
 
-  '@azure/identity@4.12.0':
-    resolution: {integrity: sha512-6vuh2R3Cte6SD6azNalLCjIDoryGdcvDVEV7IDRPtm5lHX5ffkDlIalaoOp5YJU08e4ipjJENel20kSMDLAcug==}
+  '@azure/identity@4.13.1':
+    resolution: {integrity: sha512-5C/2WD5Vb1lHnZS16dNQRPMjN6oV/Upba+C9nBIs15PmOi6A3ZGs4Lr2u60zw4S04gi+u3cEXiqTVP7M4Pz3kw==}
     engines: {node: '>=20.0.0'}
 
   '@azure/keyvault-common@2.0.1':
@@ -495,21 +507,29 @@ packages:
     resolution: {integrity: sha512-ITyx79SE6vb8fOk3NzZ+bTYEET6P+eTecx2lFLIQTFqkJe0HiFna1vuoXkXghQhMtL8+tRTDwKomAP/2H0/YJQ==}
     engines: {node: '>=20.0.0'}
 
-  '@azure/msal-browser@4.23.0':
-    resolution: {integrity: sha512-uHnfRwGAEHaYVXzpCtYsruy6PQxL2v76+MJ3+n/c/3PaTiTIa5ch7VofTUNoA39nHyjJbdiqTwFZK40OOTOkjw==}
+  '@azure/msal-browser@5.10.1':
+    resolution: {integrity: sha512-hTbvOi9Ko2Jvn+G/fSmjzHf9WbNcf/o3epMtbeGx/pMwMrVAbi6OgCJVeCfsAb8IybSRpaCSc4EDRlYAhgngUQ==}
     engines: {node: '>=0.8.0'}
 
-  '@azure/msal-common@15.12.0':
-    resolution: {integrity: sha512-4ucXbjVw8KJ5QBgnGJUeA07c8iznwlk5ioHIhI4ASXcXgcf2yRFhWzYOyWg/cI49LC9ekpFJeQtO3zjDTbl6TQ==}
+  '@azure/msal-common@16.6.1':
+    resolution: {integrity: sha512-VxKdEtUwDuLD0F1hOQP7kye0YadZxFJfv37Em440geEf/w9uggKnHpRrqwZJOdxmPUOdhZ9kyRtKuAJW8wUcRg==}
     engines: {node: '>=0.8.0'}
 
-  '@azure/msal-node@3.7.4':
-    resolution: {integrity: sha512-fjqvhrThwzzPvqhFOdkkGRJCHPQZTNijpceVy8QjcfQuH482tOVEjHyamZaioOhVtx+FK1u+eMpJA2Zz4U9LVg==}
-    engines: {node: '>=16'}
+  '@azure/msal-node@5.2.1':
+    resolution: {integrity: sha512-tmQiQ2HvtzaeLqYGy3BemiPOSGPY4wCy1IW5zDWITKSs/s35WEd7Zij/hCxvUdAOzj6U3qnyaGbYXY91ortFEQ==}
+    engines: {node: '>=20'}
 
   '@azure/opentelemetry-instrumentation-azure-sdk@1.0.0-beta.9':
     resolution: {integrity: sha512-gNCFokEoQQEkhu2T8i1i+1iW2o9wODn2slu5tpqJmjV1W7qf9dxVv6GNXW1P1WC8wMga8BCc2t/oMhOK3iwRQg==}
     engines: {node: '>=18.0.0'}
+
+  '@azure/storage-common@12.3.0':
+    resolution: {integrity: sha512-/OFHhy86aG5Pe8dP5tsp+BuJ25JOAl9yaMU3WZbkeoiFMHFtJ7tu5ili7qEdBXNW9G5lDB19trwyI6V49F/8iQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@azure/storage-queue@12.29.0':
+    resolution: {integrity: sha512-p02H+TbPQWSI/SQ4CG+luoDvpenM+4837NARmOE4oPNOR5vAq7qRyeX72ffyYL2YLnkcyxETh28/bp/TiVIM+g==}
+    engines: {node: '>=20.0.0'}
 
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
@@ -2590,6 +2610,7 @@ packages:
 
   dottie@2.0.6:
     resolution: {integrity: sha512-iGCHkfUc5kFekGiqhe8B/mdaurD+lakO9txNnTvKtA6PISrw86LgqHvRzWYPyoE2Ph5aMIrCw9/uko6XHTKCwA==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   dreamopt@0.8.0:
     resolution: {integrity: sha512-vyJTp8+mC+G+5dfgsY+r3ckxlz+QMX40VjPQsZc5gxVAxLmi64TBoVkP54A/pRAXMXsbu2GMMBrZPxNv23waMg==}
@@ -2804,6 +2825,10 @@ packages:
   event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
+
+  events@3.3.0:
+    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
+    engines: {node: '>=0.8.x'}
 
   exec-sh@0.2.2:
     resolution: {integrity: sha512-FIUCJz1RbuS0FKTdaAafAByGS0CPvU3R0MeHxgtl+djzCc//F8HakL8GzmVNZanasTbTAY/3DRFA0KpVqj/eAw==}
@@ -3069,11 +3094,12 @@ packages:
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   globals@13.24.0:
     resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}
@@ -5461,11 +5487,12 @@ packages:
 
   uuid@3.4.0:
     resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
-    deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-to-istanbul@9.3.0:
@@ -5518,6 +5545,7 @@ packages:
 
   whatwg-encoding@1.0.5:
     resolution: {integrity: sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-url@4.8.0:
     resolution: {integrity: sha512-nUvUPuenPFtPfy/X+dAYh/TfRbTBlnXTM5iIfLseJFkkQewmpG9pGR6i87E9qL+lZaJzv+99kkQWoGOtLfkZQQ==}
@@ -5830,7 +5858,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@azure/data-tables@13.3.1':
+  '@azure/data-tables@13.3.2':
     dependencies:
       '@azure/core-auth': 1.10.1
       '@azure/core-client': 1.10.1
@@ -5863,7 +5891,7 @@ snapshots:
       long: 4.0.0
       undici: 5.29.0
 
-  '@azure/identity@4.12.0':
+  '@azure/identity@4.13.1':
     dependencies:
       '@azure/abort-controller': 2.1.2
       '@azure/core-auth': 1.10.1
@@ -5872,8 +5900,8 @@ snapshots:
       '@azure/core-tracing': 1.3.1
       '@azure/core-util': 1.13.1
       '@azure/logger': 1.3.0
-      '@azure/msal-browser': 4.23.0
-      '@azure/msal-node': 3.7.4
+      '@azure/msal-browser': 5.10.1
+      '@azure/msal-node': 5.2.1
       open: 10.2.0
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -5967,17 +5995,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@azure/msal-browser@4.23.0':
+  '@azure/msal-browser@5.10.1':
     dependencies:
-      '@azure/msal-common': 15.12.0
+      '@azure/msal-common': 16.6.1
 
-  '@azure/msal-common@15.12.0': {}
+  '@azure/msal-common@16.6.1': {}
 
-  '@azure/msal-node@3.7.4':
+  '@azure/msal-node@5.2.1':
     dependencies:
-      '@azure/msal-common': 15.12.0
+      '@azure/msal-common': 16.6.1
       jsonwebtoken: 9.0.2
-      uuid: 8.3.2
 
   '@azure/opentelemetry-instrumentation-azure-sdk@1.0.0-beta.9':
     dependencies:
@@ -5987,6 +6014,37 @@ snapshots:
       '@opentelemetry/core': 2.1.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation': 0.200.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-web': 2.1.0(@opentelemetry/api@1.9.0)
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/storage-common@12.3.0':
+    dependencies:
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-auth': 1.10.1
+      '@azure/core-http-compat': 2.3.1
+      '@azure/core-rest-pipeline': 1.22.1
+      '@azure/core-tracing': 1.3.1
+      '@azure/core-util': 1.13.1
+      '@azure/logger': 1.3.0
+      events: 3.3.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/storage-queue@12.29.0':
+    dependencies:
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-auth': 1.10.1
+      '@azure/core-client': 1.10.1
+      '@azure/core-http-compat': 2.3.1
+      '@azure/core-paging': 1.6.2
+      '@azure/core-rest-pipeline': 1.22.1
+      '@azure/core-tracing': 1.3.1
+      '@azure/core-util': 1.13.1
+      '@azure/core-xml': 1.5.0
+      '@azure/logger': 1.3.0
+      '@azure/storage-common': 12.3.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -7262,7 +7320,7 @@ snapshots:
   '@pagopa/io-functions-commons@30.0.0(@azure/functions@4.11.2)(@pagopa/ts-commons@13.1.2(fp-ts@2.16.11)(io-ts@2.2.22(fp-ts@2.16.11)))(express@4.21.2)(fp-ts@2.16.11)(io-ts@2.2.22(fp-ts@2.16.11))':
     dependencies:
       '@azure/cosmos': 4.5.1
-      '@azure/data-tables': 13.3.1
+      '@azure/data-tables': 13.3.2
       '@azure/functions': 4.11.2
       '@pagopa/ts-commons': 13.1.2(fp-ts@2.16.11)(io-ts@2.2.22(fp-ts@2.16.11))
       applicationinsights: 2.9.8
@@ -7293,7 +7351,7 @@ snapshots:
   '@pagopa/io-functions-commons@30.0.0(@azure/functions@4.8.0)(@pagopa/ts-commons@11.0.0)(express@4.21.2)(fp-ts@2.16.11)(io-ts@2.2.22(fp-ts@2.16.11))':
     dependencies:
       '@azure/cosmos': 4.5.1
-      '@azure/data-tables': 13.3.1
+      '@azure/data-tables': 13.3.2
       '@azure/functions': 4.8.0
       '@pagopa/ts-commons': 11.0.0
       applicationinsights: 2.9.8
@@ -7324,7 +7382,7 @@ snapshots:
   '@pagopa/io-functions-commons@30.0.0(@azure/functions@4.8.0)(@pagopa/ts-commons@13.1.2(fp-ts@2.16.11)(io-ts@2.2.22(fp-ts@2.16.11)))(express@4.21.2)(fp-ts@2.16.11)(io-ts@2.2.22(fp-ts@2.16.11))':
     dependencies:
       '@azure/cosmos': 4.5.1
-      '@azure/data-tables': 13.3.1
+      '@azure/data-tables': 13.3.2
       '@azure/functions': 4.8.0
       '@pagopa/ts-commons': 13.1.2(fp-ts@2.16.11)(io-ts@2.2.22(fp-ts@2.16.11))
       applicationinsights: 2.9.8
@@ -7972,7 +8030,7 @@ snapshots:
       '@azure/core-auth': 1.10.1
       '@azure/functions': 4.11.2
       '@azure/functions-old': '@azure/functions@3.5.1'
-      '@azure/identity': 4.12.0
+      '@azure/identity': 4.13.1
       '@azure/monitor-opentelemetry': 1.14.0
       '@azure/monitor-opentelemetry-exporter': 1.0.0-beta.35
       '@azure/opentelemetry-instrumentation-azure-sdk': 1.0.0-beta.9
@@ -8932,6 +8990,8 @@ snapshots:
   etag@1.8.1: {}
 
   event-target-shim@5.0.1: {}
+
+  events@3.3.0: {}
 
   exec-sh@0.2.2:
     dependencies:


### PR DESCRIPTION
The legacy `azure-storage` SDK authenticates via a connection string. Replacing it with the modern Azure SDKs allows the function apps to authenticate to Azure Storage using the managed identity granted in the previous infrastructure PR.

**card-func** changes:
- Replace `azure-storage` with `@azure/storage-queue`, `@azure/data-tables`, and `@azure/identity`
- Swap `CGN_STORAGE_CONNECTION_STRING` config for `CGN_STORAGE_ACCOUNT_NAME`
- Change 9 queue trigger `connection` values from `CGN_STORAGE_CONNECTION_STRING` to `CGN_STORAGE`, enabling identity-based authentication by the Azure Functions runtime
- Rewrite `QueueStorage` class, `TableClient` helpers, and health checks to use `DefaultAzureCredential`
- Update table storage tests to mock the new SDK interface

**support-func** changes:
- Remove `CGN_STORAGE_CONNECTION_STRING`, `CGN_EXPIRATION_TABLE_NAME`, `EYCA_EXPIRATION_TABLE_NAME` from config — these were injected but never used by any handler at runtime
- Remove the corresponding storage health check (no storage access in support-func)

Resolves CES-2053

Depends on #136

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>