### PR TITLE
Remove legacy storage connection string from function app settings

### DIFF
--- a/infra-io/resources/_modules/function_app_card/locals.tf
+++ b/infra-io/resources/_modules/function_app_card/locals.tf
@@ -20,9 +20,6 @@ locals {
       CGN_STORAGE__serviceUri  = "https://${var.storage_cgn_account_name}.queue.core.windows.net"
       CGN_STORAGE_ACCOUNT_NAME = var.storage_cgn_account_name
 
-      // STORAGE (legacy connection string - kept for backward compat, removed in a following PR)
-      CGN_STORAGE_CONNECTION_STRING = var.storage_cgn_connection_string
-
       // TABLE STORAGE
       CGN_EXPIRATION_TABLE_NAME  = var.table_cgn_expiration
       EYCA_EXPIRATION_TABLE_NAME = var.table_eyca_expiration

--- a/infra-io/resources/_modules/function_app_card/variables.tf
+++ b/infra-io/resources/_modules/function_app_card/variables.tf
@@ -131,11 +131,6 @@ variable "storage_cgn_account_name" {
   description = "CGN storage account name (used for identity-based RBAC connections)"
 }
 
-variable "storage_cgn_connection_string" {
-  type        = string
-  description = "CGN storage connection key"
-}
-
 variable "table_cgn_expiration" {
   type        = string
   description = "CGN expiration table name"

--- a/infra-io/resources/_modules/function_app_support/locals.tf
+++ b/infra-io/resources/_modules/function_app_support/locals.tf
@@ -9,13 +9,6 @@ locals {
       COSMOSDB_CGN_KEY           = var.cosmosdb_cgn_key
       COSMOSDB_CGN_DATABASE_NAME = var.cosmosdb_cgn_database_name
 
-      // STORAGE
-      CGN_STORAGE_CONNECTION_STRING = var.storage_cgn_connection_string
-
-      // TABLE STORAGE
-      CGN_EXPIRATION_TABLE_NAME  = var.table_cgn_expiration
-      EYCA_EXPIRATION_TABLE_NAME = var.table_eyca_expiration
-
       // Keepalive fields are all optionals
       FETCH_KEEPALIVE_ENABLED             = "true"
       FETCH_KEEPALIVE_SOCKET_ACTIVE_TTL   = "110000"

--- a/infra-io/resources/_modules/function_app_support/variables.tf
+++ b/infra-io/resources/_modules/function_app_support/variables.tf
@@ -105,18 +105,3 @@ variable "cosmosdb_cgn_database_name" {
   type        = string
   description = "Database name for CGN cosmosdb"
 }
-
-variable "storage_cgn_connection_string" {
-  type        = string
-  description = "CGN storage connection key"
-}
-
-variable "table_cgn_expiration" {
-  type        = string
-  description = "CGN expiration table name"
-}
-
-variable "table_eyca_expiration" {
-  type        = string
-  description = "EYCA expiration table name"
-}

--- a/infra-io/resources/prod/func_card.tf
+++ b/infra-io/resources/prod/func_card.tf
@@ -33,7 +33,6 @@ module "functions_cgn_card_02" {
   cosmosdb_cgn_database_name = "db"
 
   storage_cgn_account_name      = data.azurerm_storage_account.storage_cgn_itn.name
-  storage_cgn_connection_string = data.azurerm_key_vault_secret.storage_cgn_connection_string.value
 
   table_cgn_expiration  = "cardexpiration"
   table_eyca_expiration = "eycacardexpiration"

--- a/infra-io/resources/prod/func_support.tf
+++ b/infra-io/resources/prod/func_support.tf
@@ -30,10 +30,5 @@ module "functions_cgn_support_01" {
   cosmosdb_cgn_key           = data.azurerm_key_vault_secret.cosmosdb_cgn_key.value
   cosmosdb_cgn_database_name = "db"
 
-  storage_cgn_connection_string = data.azurerm_key_vault_secret.storage_cgn_connection_string.value
-
-  table_cgn_expiration  = "cardexpiration"
-  table_eyca_expiration = "eycacardexpiration"
-
   tags = local.tags
 }


### PR DESCRIPTION
With the application code migrated to identity-based storage access, the `CGN_STORAGE_CONNECTION_STRING` app setting and related table name settings are no longer needed and can be dropped from the Terraform modules.

- `function_app_card`: remove `CGN_STORAGE_CONNECTION_STRING` app setting and `storage_cgn_connection_string` variable
- `function_app_support`: remove `CGN_STORAGE_CONNECTION_STRING`, `CGN_EXPIRATION_TABLE_NAME`, `EYCA_EXPIRATION_TABLE_NAME` app settings and their variables
- `prod/func_card.tf` and `prod/func_support.tf`: remove the corresponding parameter assignments

Resolves CES-2008

Depends on #137

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>