### PR TITLE
Remove storage connection string Key Vault secret data source

### DIFF
--- a/infra-io/resources/prod/data.tf
+++ b/infra-io/resources/prod/data.tf
@@ -74,11 +74,6 @@ data "azurerm_key_vault_secret" "cosmosdb_cgn_key" {
   key_vault_id = module.key_vaults.key_vault_cgn.id
 }
 
-data "azurerm_key_vault_secret" "storage_cgn_connection_string" {
-  name         = "STORAGE-CGN-CONNECTION-STRING"
-  key_vault_id = module.key_vaults.key_vault_cgn.id
-}
-
 data "azurerm_api_management" "apim_platform" {
   name                = "io-p-itn-platform-api-gateway-apim-01"
   resource_group_name = "io-p-itn-common-rg-01"


### PR DESCRIPTION
Now that no Terraform resource references `data.azurerm_key_vault_secret.storage_cgn_connection_string`, the data source can be removed. This stops Terraform from querying the `STORAGE-CGN-CONNECTION-STRING` secret at plan/apply time.

The secret itself in Azure Key Vault can be deleted manually by the ops team as a separate cleanup step once this PR is deployed.

Resolves CES-2008

Depends on #138

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>