### PR TITLE
chore: bump `js_code_review` version to its latest

### DIFF
--- a/.github/workflows/code-review.yaml
+++ b/.github/workflows/code-review.yaml
@@ -3,14 +3,14 @@ name: Code Review
 on:
   workflow_dispatch:
   pull_request:
-    types: [ opened, synchronize ]
+    types: [opened, synchronize]
     paths:
       - apps/**
       - packages/**
 
 jobs:
   js_code_review:
-    uses: pagopa/dx/.github/workflows/js_code_review.yaml@5084d6f93194b71fdb40243e0d489d39cbe71958
+    uses: pagopa/dx/.github/workflows/js_code_review.yaml@af75138d40e08b98e63696e26ce545004a769565
     name: Code Review
     secrets: inherit
     permissions:


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for JavaScript code review to use a newer version of the shared workflow.

Workflow configuration update:

* The `js_code_review` job in `.github/workflows/code-review.yaml` now references the latest commit (`af75138d40e08b98e63696e26ce545004a769565`) of the shared workflow instead of the previous version.

[Run](https://github.com/pagopa/io-cgn/actions/runs/26091988767): ✅ 

Closes [IEG-2922](https://pagopa.atlassian.net/browse/IEG-2922)

[IEG-2922]: https://pagopa.atlassian.net/browse/IEG-2922?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ