### PR TITLE
refactor: use `dx` instead of `io-infra` cert renewal workflow

### DIFF
--- a/.github/workflows/renew_agw_certificates.yaml
+++ b/.github/workflows/renew_agw_certificates.yaml
@@ -7,29 +7,27 @@ on:
 
 jobs:
   renew_uat:
-    uses: pagopa/io-infra/.github/workflows/ssl_certificate_renewal.yaml@b04e50d300f48d840b77d5e913ede0d8a605aa4f
+    uses: pagopa/dx/.github/workflows/release-certificate-v1.yaml@main
     name: Renew PE UAT certificate
     secrets: inherit
     with:
         csr_common_name: api.cgnonboardingportal-uat.pagopa.it
-        azure_dns_zone_resource_group: cgnonboardingportal-u-public-rg
-        azure_dns_zone: cgnonboardingportal-uat.pagopa.it
+        dns_zone_resource_group: cgnonboardingportal-u-public-rg
+        dns_zone: cgnonboardingportal-uat.pagopa.it
         key_vault_name: io-u-itn-cgn-pe-kv-01
-        force_renew_cert: true
-        environment: pe-uat
-        use_selfhosted_agent: true
+        force_renewal: true
+        environment: pe-uat        
 
   renew_prod:
-    uses: pagopa/io-infra/.github/workflows/ssl_certificate_renewal.yaml@b04e50d300f48d840b77d5e913ede0d8a605aa4f
+    uses: pagopa/dx/.github/workflows/release-certificate-v1.yaml@main
     name: Renew PE PROD certificate
     secrets: inherit
     needs: [renew_uat]
     with:
         csr_common_name: api.cgnonboardingportal.pagopa.it
-        azure_dns_zone_resource_group: cgnonboardingportal-p-public-rg
-        azure_dns_zone: cgnonboardingportal.pagopa.it
+        dns_zone_resource_group: cgnonboardingportal-p-public-rg
+        dns_zone: cgnonboardingportal.pagopa.it
         key_vault_name: io-p-itn-cgn-pe-kv-01
-        force_renew_cert: true
-        environment: pe-prod
-        use_selfhosted_agent: true
+        force_renewal: true
+        environment: pe-prod        
       


### PR DESCRIPTION
This pull request updates the certificate renewal workflow configuration to use a new shared workflow and aligns input parameter names with the new workflow's requirements. The main goal is to switch from a legacy workflow to a new, standardized one and ensure compatibility.

**Workflow migration:**

* The workflow now uses `pagopa/dx/.github/workflows/release-certificate-v1.yaml@main` instead of the previous `pagopa/io-infra/.github/workflows/ssl_certificate_renewal.yaml`.

**Input parameter updates for compatibility:**

* Renamed input parameters from `azure_dns_zone_resource_group` and `azure_dns_zone` to `dns_zone_resource_group` and `dns_zone` to match the new workflow.
* Changed `force_renew_cert` to `force_renewal` to align with the new workflow's expected parameters.
* Removed the `use_selfhosted_agent` parameter, which is not required by the new workflow.